### PR TITLE
appending an asterisk to our callsign in digipeated packet

### DIFF
--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -2458,7 +2458,9 @@ add_our_data:
     sprintf(buf + strlen(buf), ",%s", snr_rssi);
 
   if (add_our_call)
-    sprintf(buf + strlen(buf), ",%s", Tcall.c_str());
+  {
+    sprintf(buf + strlen(buf), ",%s*", Tcall.c_str());
+  }
 
   for (i = insert_our_data_before; i < frame->n_digis; i++) {
     sprintf(buf + strlen(buf), ",%s", frame->digis[i].addr);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/17248077/190846017-09fb9dbd-29b4-46dc-b075-7d14b1de10b9.png)
Hi :D. Current fw version doesnt append asterix to the end of our call to inform that digipeating has been realized.