### PR TITLE
Cleaned up Watchdog handling 

### DIFF
--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -529,7 +529,7 @@ void store_compressed_position(double Tlat, double Tlon) {
     if (position_ambiguity > 0) {
       // strip off n decimals
       int i = position_ambiguity > 4 ? 4 : position_ambiguity;
-      aprs_lat = (uint32_t ) (aprs_lon / (1000 * pow(10, i)) * 1000 * pow(10, i));
+      aprs_lon = (uint32_t ) (aprs_lon / (1000 * pow(10, i)) * 1000 * pow(10, i));
     }
     aprs_lon = aprs_lon / 26 - aprs_lon / 2710 + aprs_lon / 15384615;
 

--- a/src/TTGO_T-Beam_LoRa_APRS.ino
+++ b/src/TTGO_T-Beam_LoRa_APRS.ino
@@ -3224,6 +3224,9 @@ void setup()
   // for diagnostics
   uint32_t t_setup_entered = millis();
 
+  // initialize ESP32 Process WDT, 120s T/O
+  esp_task_wdt_init(120, true);
+
   // Our BUILD_NUMBER. The define is not available in the WEBSERVR -> we need to assign a global variable
   buildnr = BUILD_NUMBER;
 
@@ -3508,8 +3511,8 @@ void setup()
 #endif /* ENABLE_WIFI */
 
 
-  esp_task_wdt_init(120, true); //enable panic so ESP32 restarts
   esp_task_wdt_add(NULL); //add current thread to WDT watch
+  esp_task_wdt_reset();
 
   setup_oled_timer_values();
 

--- a/src/taskGPS.cpp
+++ b/src/taskGPS.cpp
@@ -45,7 +45,7 @@ bool gpsInitialized = false;
   }
 
 
-  esp_task_wdt_init(120, true); //enable panic so ESP32 restarts
+  // esp_task_wdt_init() has already been done in main task.
   esp_task_wdt_add(NULL); //add current thread to WDT watch
 
   String gpsDataBuffer = "              ";

--- a/src/taskTNC.cpp
+++ b/src/taskTNC.cpp
@@ -79,7 +79,7 @@ void handleKISSData(char character, int bufferIndex) {
   tncReceivedQueue = xQueueCreate(4,sizeof(String *));
   String *loraReceivedFrameString = nullptr;
 
-  esp_task_wdt_init(120, true); //enable panic so ESP32 restarts
+  // esp_task_wdt_init() has already been done in main task.
   esp_task_wdt_add(NULL); //add current thread to WDT watch
 
   while (true) {

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -1922,6 +1922,7 @@ void send_to_aprsis()
 
   // esp_task_wdt_init() has already been done in main task.
   esp_task_wdt_add(NULL); //add current thread to WDT watch
+  esp_task_wdt_reset();
 
   // 8 characters is requirements for WPA2
   // May be already set by wifi.cfg

--- a/src/taskWebServer.cpp
+++ b/src/taskWebServer.cpp
@@ -495,7 +495,7 @@ void refill_preferences_as_jsonData()
   } else {
     s_tmp = aprsLatPresetNiceNotation + " " + aprsLonPresetNiceNotation + " [" + (aprsPresetShown == "" ? "GPS" : aprsPresetShown) + "]";
   }
-  s = s + jsonLineFromString("curPos", s_tmp.c_str());
+  s = s + "\n  " +  jsonLineFromString("curPos", s_tmp.c_str());
   s = s + "\n  " +  jsonLineFromInt("UptimeMinutes", millis()/1000/60);
   s = s + "\n  " +  jsonLineFromString("OledLine1", OledLine1.c_str());
   s = s + "\n  " +  jsonLineFromString("OledLine2", OledLine2.c_str());
@@ -1459,12 +1459,14 @@ void do_send_status_message_about_connect_to_aprsis(void) {
 
   outString.replace(":>", ",RFONLY:>");
   if (lora_tx_enabled && tx_own_beacon_from_this_device_or_fromKiss__to_frequencies) {
-    esp_task_wdt_reset();
-    if (tx_own_beacon_from_this_device_or_fromKiss__to_frequencies % 2)
+    if (tx_own_beacon_from_this_device_or_fromKiss__to_frequencies % 2) {
+      esp_task_wdt_reset();
       loraSend(txPower, lora_freq, lora_speed, 0, outString);  //send the packet, data is in TXbuff from lora_TXStart to lora_TXEnd
-    esp_task_wdt_reset();
-    if (tx_own_beacon_from_this_device_or_fromKiss__to_frequencies > 1 && lora_digipeating_mode > 1 && lora_freq_cross_digi > 1.0 && lora_freq_cross_digi != lora_freq)
+    }
+    if (tx_own_beacon_from_this_device_or_fromKiss__to_frequencies > 1 && lora_digipeating_mode > 1 && lora_freq_cross_digi > 1.0 && lora_freq_cross_digi != lora_freq) {
+      esp_task_wdt_reset();
       loraSend(txPower_cross_digi, lora_freq_cross_digi, lora_speed_cross_digi, 0, outString);  //send the packet, data is in TXbuff from lora_TXStart to lora_TXEnd
+    }
   }
 
   esp_task_wdt_reset();
@@ -1495,7 +1497,7 @@ int connect_to_aprsis(void) {
   aprsis_status = "Connected. Waiting for greeting.";
 
   uint32_t t_start = millis();
-  while (!aprsis_client.available() && (millis()-t_start) < 25000L) { delay(100); esp_task_wdt_reset(); }
+  while (!aprsis_client.available() && (millis()-t_start) < 25000L) { vTaskDelay(100 / portTICK_PERIOD_MS); esp_task_wdt_reset(); }
   if (aprsis_client.available()) {
     // check
     String s = aprsis_client.readStringUntil('\n');
@@ -1517,7 +1519,7 @@ int connect_to_aprsis(void) {
   aprsis_client.print(String(buffer) + "\r\n");
 
   t_start = millis();
-  while (!aprsis_client.available() && (millis()-t_start) < 25000L) { delay(100); esp_task_wdt_reset(); }
+  while (!aprsis_client.available() && (millis()-t_start) < 25000L) { vTaskDelay(100 / portTICK_PERIOD_MS); esp_task_wdt_reset(); }
   if (aprsis_client.available()) {
     // check
     String s = aprsis_client.readStringUntil('\n');
@@ -1793,6 +1795,7 @@ void read_from_aprsis(void) {
         loraSend(txPower, lora_freq, lora_speed, 0, third_party_packet);
       }
       if (aprsis_data_allow_inet_to_rf > 1 && lora_freq_cross_digi > 1.0 && lora_freq_cross_digi != lora_freq) {
+        esp_task_wdt_reset();
         loraSend(txPower_cross_digi, lora_freq_cross_digi, lora_speed_cross_digi, 0, third_party_packet);
         esp_task_wdt_reset();
       }
@@ -1917,7 +1920,7 @@ void send_to_aprsis()
   server.onNotFound(handle_NotFound);
 
 
-  esp_task_wdt_init(120, true); //enable panic so ESP32 restarts
+  // esp_task_wdt_init() has already been done in main task.
   esp_task_wdt_add(NULL); //add current thread to WDT watch
 
   // 8 characters is requirements for WPA2
@@ -1997,6 +2000,7 @@ void send_to_aprsis()
   uint32_t webserver_started = millis();
 
 
+  // main loop
   while (true) {
     esp_task_wdt_reset();
 


### PR DESCRIPTION
- esp_task_wdt_init() must only be called once to initialize
  the watchdog. The task* cpp files have been changed to address
  this.
  -> <https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-reference/system/wdts.html#_CPPv417esp_task_wdt_initPK21esp_task_wdt_config_t>
- replaced some delay() on long running operations with vTaskDelay
- rearranged some esp_task_wdt_reset() calls - will ot make a real
  difference, just looks better.
- minor cosmetic change in preference dump to serial